### PR TITLE
Update http2curl.go

### DIFF
--- a/http2curl.go
+++ b/http2curl.go
@@ -48,8 +48,8 @@ func GetCurlCommand(req *http.Request) (*CurlCommand, error) {
 			return nil, err
 		}
 		req.Body = nopCloser{bytes.NewBuffer(body)}
-		bodyEscaped := bashEscape(string(body))
-		if len(bodyEscaped) != '' {
+		if len(string(body)) > 0 {
+			bodyEscaped := bashEscape(string(body))
 			command.append("-d", bodyEscaped)
 		}
 	}


### PR DESCRIPTION
added a check on the body length to avoid adding `-d ''` to the request.